### PR TITLE
feat: support repartition with partition key

### DIFF
--- a/core/src/executor/datafusion/mod.rs
+++ b/core/src/executor/datafusion/mod.rs
@@ -94,6 +94,7 @@ impl CompactionExecutor for DataFusionExecutor {
             batch_parallelism,
             target_partitions,
             file_io.clone(),
+            partition_spec.clone(),
         )
         .execute()
         .await?;


### PR DESCRIPTION
If an Iceberg table has partition keys, we need partition the data for partition key; otherwise, it will result in excessive file writes.