### PR TITLE
feat: support mutil async read file

### DIFF
--- a/core/src/executor/datafusion/file_scan_task_table_provider.rs
+++ b/core/src/executor/datafusion/file_scan_task_table_provider.rs
@@ -38,6 +38,7 @@ pub struct IcebergFileScanTaskTableProvider {
     need_seq_num: bool,
     need_file_path_and_pos: bool,
     batch_parallelism: usize,
+    read_file_parallelism: usize,
 }
 impl IcebergFileScanTaskTableProvider {
     pub fn new(
@@ -47,6 +48,7 @@ impl IcebergFileScanTaskTableProvider {
         need_seq_num: bool,
         need_file_path_and_pos: bool,
         batch_parallelism: usize,
+        read_file_parallelism: usize,
     ) -> Self {
         Self {
             file_scan_tasks,
@@ -55,6 +57,7 @@ impl IcebergFileScanTaskTableProvider {
             need_seq_num,
             need_file_path_and_pos,
             batch_parallelism,
+            read_file_parallelism,
         }
     }
 }
@@ -92,6 +95,7 @@ impl TableProvider for IcebergFileScanTaskTableProvider {
             self.need_seq_num,
             self.need_file_path_and_pos,
             self.batch_parallelism,
+            self.read_file_parallelism,
         )))
     }
 

--- a/core/src/executor/datafusion/mod.rs
+++ b/core/src/executor/datafusion/mod.rs
@@ -86,6 +86,7 @@ impl CompactionExecutor for DataFusionExecutor {
             config.batch_parallelism,
             config.target_partitions,
             file_io.clone(),
+            4,
         )
         .execute()
         .await?;
@@ -95,7 +96,7 @@ impl CompactionExecutor for DataFusionExecutor {
         for mut batch in batchs {
             let dir_path = dir_path.clone();
             let schema = arc_input_schema.clone();
-            let data_file_prefix = (&config.data_file_prefix).clone();
+            let data_file_prefix = config.data_file_prefix.clone();
             let target_file_size = config.target_file_size;
             let file_io = file_io.clone();
             let partition_spec = partition_spec.clone();

--- a/core/src/executor/iceberg_writer/rolling_iceberg_writer.rs
+++ b/core/src/executor/iceberg_writer/rolling_iceberg_writer.rs
@@ -73,7 +73,7 @@ pub fn need_build_new_file(
     target_file_size: usize,
 ) -> bool {
     // If the current file size is less than 10% of the target size, don't build a new file.
-    if current_written_size < target_file_size * 1 / 10 {
+    if current_written_size < target_file_size / 10 {
         return false;
     }
     // If the total size of the current file and the new batch would exceed 1.5x the target size, build a new file.


### PR DESCRIPTION
This pull request introduces a new `read_file_parallelism` parameter across several components of the DataFusion-based execution framework to enhance parallelism in file reading operations. Additionally, it includes minor fixes and refactors in related modules.

### Enhancements for Parallel File Reading:
* [`core/src/executor/datafusion/datafusion_processor.rs`](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fR52): Added `read_file_parallelism` as a parameter to `DatafusionProcessor` and its methods, ensuring it is passed to relevant table registration and file scan operations. [[1]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fR52) [[2]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fR62) [[3]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fR84) [[4]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fR116)
* [`core/src/executor/datafusion/file_scan_task_table_provider.rs`](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcR41): Updated `IcebergFileScanTaskTableProvider` to include `read_file_parallelism` for better control over concurrent file scans. [[1]](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcR41) [[2]](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcR51) [[3]](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcR98)
* [`core/src/executor/datafusion/iceberg_file_task_scan.rs`](diffhunk://#diff-49fda4940475cd762e16845a9cc66ebda5f41751ae015ac46b4dc0df4259139bR227-R269): Refactored `get_batch_stream` to use `tokio::sync::mpsc` and `try_for_each_concurrent` for file reading, leveraging `read_file_parallelism` for improved concurrency. [[1]](diffhunk://#diff-49fda4940475cd762e16845a9cc66ebda5f41751ae015ac46b4dc0df4259139bR227-R269) [[2]](diffhunk://#diff-49fda4940475cd762e16845a9cc66ebda5f41751ae015ac46b4dc0df4259139bL245-R279)

### Minor Fixes and Refactors:
* [`core/src/executor/datafusion/mod.rs`](diffhunk://#diff-3967917dd0985da6644fb89b2b1c534021155a64f317a378e71513dbbe01b5c2R89): Set a default value of `4` for `read_file_parallelism` in the `DataFusionExecutor` implementation.
* [`core/src/executor/iceberg_writer/rolling_iceberg_writer.rs`](diffhunk://#diff-ec9220cb08bd2bbf8dbdb6e01d19067923f89166aad92a32bebc58e06e5e9f6dL76-R76): Simplified a mathematical expression in the `need_build_new_file` function for better readability.