### PR TITLE
fix: fix register eq delete table name

### DIFF
--- a/core/src/compaction/validator.rs
+++ b/core/src/compaction/validator.rs
@@ -84,13 +84,13 @@ impl CompactionValidator {
             .with_schema(input_schema)
             .with_input_data_files(input_file_scan_tasks)
             .with_table_prefix("input".to_owned())
-            .build_merge_on_read()?;
+            .build()?;
 
         let output_datafusion_task_ctx = DataFusionTaskContext::builder()?
             .with_schema(output_schema)
             .with_data_files(output_file_scan_tasks)
             .with_table_prefix("output".to_owned())
-            .build_merge_on_read()?;
+            .build()?;
 
         let validator_config = Arc::new(
             CompactionConfigBuilder::default()

--- a/core/src/executor/datafusion/mod.rs
+++ b/core/src/executor/datafusion/mod.rs
@@ -65,7 +65,7 @@ impl CompactionExecutor for DataFusionExecutor {
         let datafusion_task_ctx = DataFusionTaskContext::builder()?
             .with_schema(schema)
             .with_input_data_files(input_file_scan_tasks)
-            .build_merge_on_read()?;
+            .build()?;
         let (batches, input_schema) = DatafusionProcessor::new(config.clone(), file_io.clone())
             .execute(datafusion_task_ctx)
             .await?;


### PR DESCRIPTION
This pull request refactors table name generation and simplifies the `DataFusionTaskContext` building process. The changes aim to improve code readability, maintainability, and reduce redundancy by centralizing table name logic in a new `table_name` module.

Fix the bug caused by an incorrectly built EQ delete name with table prefixes.

### Refactoring Table Name Generation:
* [`core/src/executor/datafusion/datafusion_processor.rs`](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fR601-R626): Introduced a new `table_name` module to centralize table name generation logic, including functions for building names for data file, position delete, and equality delete tables. This replaces inline `format!` calls with dedicated helper methods.
* [`core/src/executor/datafusion/datafusion_processor.rs`](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fR555-R566): Added methods to `DataFusionTaskContext` for retrieving table names using the centralized `table_name` module. These methods improve encapsulation and reduce repetitive code.

### Simplifying `DataFusionTaskContext` Building:
Rename `build_merge_on_read` to the new `build` method